### PR TITLE
[21기 박준우] Add: 하단네비 페이지 토큰에 따른 조건부 렌더링 추가

### DIFF
--- a/src/components/BottomNav/BottomNav.js
+++ b/src/components/BottomNav/BottomNav.js
@@ -1,27 +1,72 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Link, useHistory } from 'react-router-dom';
 import { flexSet } from '../../styles/mixin';
 
-const BottomNav = () => (
-  <BottomNavWrapper>
-    <IconWrapper>
-      <Icon alt="home" src="/Icon/home.png" />
-      <IconTitle>홈</IconTitle>
-    </IconWrapper>
-    <IconWrapper>
-      <Icon alt="Bookmark" src="/Icon/bookmark.png" />
-      <IconTitle>찜</IconTitle>
-    </IconWrapper>
-    <IconWrapper>
-      <Icon alt="My page" src="/Icon/my.png" />
-      <IconTitle>마이</IconTitle>
-    </IconWrapper>
-    <IconWrapper>
-      <Icon alt="Login" src="/Icon/login.png" />
-      <IconTitle>로그인</IconTitle>
-    </IconWrapper>
-  </BottomNavWrapper>
-);
+const BottomNav = () => {
+  const currentToken = localStorage.getItem('Token');
+  const history = useHistory();
+
+  const handleLogout = () => {
+    if (!window.Kakao.Auth.getAccessToken()) {
+      return;
+    }
+    window.Kakao.Auth.logout(function () {
+      localStorage.removeItem('Token');
+      alert('로그아웃 되었습니다');
+      // 일단 경고창 뜨게하고 추후 시간 남으면 모달창으로 대체
+      history.push('/');
+    });
+  };
+
+  return (
+    <BottomNavWrapper>
+      <StyledLink to="/">
+        <IconWrapper>
+          <Icon alt="home" src="/Icon/home.png" />
+          <IconTitle>홈</IconTitle>
+        </IconWrapper>
+      </StyledLink>
+      <StyledLink to="/bookmark">
+        <IconWrapper>
+          <Icon alt="Bookmark" src="/Icon/black_bookmark.png" />
+          <IconTitle>찜</IconTitle>
+        </IconWrapper>
+      </StyledLink>
+      {currentToken ? (
+        <StyledLink to="/mypage">
+          <IconWrapper>
+            <Icon alt="My page" src="/Icon/my.png" />
+            <IconTitle>마이</IconTitle>
+          </IconWrapper>
+        </StyledLink>
+      ) : (
+        <StyledLink to="/register">
+          <IconWrapper>
+            <Icon alt="My page" src="/Icon/my.png" />
+            <IconTitle>마이</IconTitle>
+          </IconWrapper>
+        </StyledLink>
+      )}
+
+      {currentToken ? (
+        <StyledLink onClick={handleLogout}>
+          <IconWrapper>
+            <Icon alt="Logout" src="/Icon/logout.png" />
+            <IconTitle>로그아웃</IconTitle>
+          </IconWrapper>
+        </StyledLink>
+      ) : (
+        <StyledLink to="/register">
+          <IconWrapper>
+            <Icon alt="Login" src="/Icon/login.png" />
+            <IconTitle>로그인</IconTitle>
+          </IconWrapper>
+        </StyledLink>
+      )}
+    </BottomNavWrapper>
+  );
+};
 
 const BottomNavWrapper = styled.section`
   width: 100%;
@@ -33,6 +78,19 @@ const BottomNavWrapper = styled.section`
   justify-content: space-between;
   align-items: center;
   border-top: 1px solid #f4f4f4;
+`;
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: black;
+
+  &:focus,
+  &:hover,
+  &:visited,
+  &:link,
+  &:active {
+    text-decoration: none;
+  }
 `;
 
 const IconWrapper = styled.section`


### PR DESCRIPTION
## 수정 사항 간략한 한줄 요약
(여기에 수정 사항에 대한 간략한 한줄 요약/제목 작성해 주세요.)
Add: 카카오 로그인 백엔드 연동 완료
- Add: 토큰에 따른 조건부 렌더링 추가
- Add: 로그아웃 기능 추가
- Add: 비로그인시 분기처리
  		 
## 수정 사항들 자세한 내용
- 카카오 회원가입 기능으로 로그인을 완료한 후 백엔드에 사용자 이미지, 닉네임, 이메일을 전송하는 테스트가 완료되었습니다.
- **localStorage**에 저장 된 Token을 기반으로 로그인 여부를 확인합니다.
- 카카오 로그아웃 기능을 활용 해 로그아웃 기능을 추가하였습니다.
- 비 로그인인 경우 마이페이지를 클릭하면 로그인 화면으로 넘어가게 처리하였습니다.

## 기타 질문 및 특이 사항
- 백엔드 팀원과 상의 후 로그아웃에 대한 DB 내의 토큰 삭제 여부를 결정할것 같습니다

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
